### PR TITLE
Add config for quorum to RpcProviderAggregator; require quorum is met if specified

### DIFF
--- a/packages/adapters/txservice/src/aggregator.ts
+++ b/packages/adapters/txservice/src/aggregator.ts
@@ -1,5 +1,6 @@
 import {
   createLoggingContext,
+  createRequestContext,
   delay,
   ERC20Abi,
   jsonifyError,
@@ -730,6 +731,20 @@ export class RpcProviderAggregator {
         }
         // Technically it could be multiple top responses...
         const topResponses = Array.from(counts.keys()).filter((k) => counts.get(k)! === maxCount);
+        if (topResponses.length > 0) {
+          // Did we get multiple conflicting top responses? Worth logging.
+          this.logger.info(
+            "Received conflicting top responses from RPC providers.",
+            createRequestContext(this.execute.name),
+            undefined,
+            {
+              topResponses,
+              providersCount: this.providers.length,
+              responsesCount: filteredResults.length,
+              requiredQuorum: quorum,
+            },
+          );
+        }
         return topResponses[0];
       }
     } else {

--- a/packages/adapters/txservice/src/aggregator.ts
+++ b/packages/adapters/txservice/src/aggregator.ts
@@ -26,6 +26,7 @@ import {
   OnchainTransaction,
   StallTimeout,
   WriteTransaction,
+  QuorumNotMet,
 } from "./shared";
 import { axiosGet } from "./mockable";
 
@@ -678,25 +679,71 @@ export class RpcProviderAggregator {
     if (needsSigner) {
       this.checkSigner();
     }
+
     const errors: NxtpError[] = [];
-    const shuffledProviders = this.shuffleSyncedProviders();
-    for (const provider of shuffledProviders) {
-      try {
-        return await method(provider);
-      } catch (e: unknown) {
-        // TODO: With the addition of SyncProvider, this parse call may be entirely redundant. Won't add any compute,
-        // however, as it will return instantly if the error is already a NxtpError.
-        const error = parseError(e);
-        if (error.type === ServerError.type || error.type === RpcError.type || error.type === StallTimeout.type) {
-          // If the method threw a StallTimeout, RpcError, or ServerError, that indicates a problem with the provider and not
-          // the call - so we'll retry the call with a different provider (if available).
-          errors.push(error);
-        } else {
-          // e.g. a TransactionReverted, TransactionReplaced, etc.
-          throw error;
+    const handleError = (e: unknown) => {
+      // TODO: With the addition of SyncProvider, this parse call may be entirely redundant. Won't add any compute,
+      // however, as it will return instantly if the error is already a NxtpError.
+      const error = parseError(e);
+      if (error.type === ServerError.type || error.type === RpcError.type || error.type === StallTimeout.type) {
+        // If the method threw a StallTimeout, RpcError, or ServerError, that indicates a problem with the provider and not
+        // the call - so we'll retry the call with a different provider (if available).
+        errors.push(error);
+      } else {
+        // e.g. a TransactionReverted, TransactionReplaced, etc.
+        throw error;
+      }
+    };
+
+    const quorum = this.config.quorum ?? 1;
+    if (quorum > 1) {
+      // Consult ALL providers.
+      const results: (T | undefined)[] = await Promise.all(
+        this.providers.map(async (provider) => {
+          try {
+            return await method(provider);
+          } catch (e: unknown) {
+            handleError(e);
+            return undefined;
+          }
+        }),
+      );
+      // Filter out undefined results.
+      // NOTE: If there aren't any defined results, we'll proceed out of this code block and throw the
+      // RpcError at the end of this method.
+      const filteredResults: T[] = results.filter((item) => item !== undefined) as T[];
+      if (filteredResults.length > 0) {
+        // Pick the most common answer.
+        let counts: Map<T, number> = new Map();
+        counts = filteredResults.reduce((counts, item) => {
+          counts.set(item, (counts.get(item) ?? 0) + 1);
+          return counts;
+        }, counts);
+        const maxCount = Math.max(...Array.from(counts.values()));
+        if (maxCount < quorum) {
+          // Quorum is not met: we should toss this response as it could be unreliable.
+          throw new QuorumNotMet(maxCount, quorum, {
+            errors,
+            providersCount: this.providers.length,
+            responsesCount: filteredResults.length,
+          });
+        }
+        // Technically it could be multiple top responses...
+        const topResponses = Array.from(counts.keys()).filter((k) => counts.get(k)! === maxCount);
+        return topResponses[0];
+      }
+    } else {
+      // Shuffle the providers (with weighting towards better ones) and pick from the top.
+      const shuffledProviders = this.shuffleSyncedProviders();
+      for (const provider of shuffledProviders) {
+        try {
+          return await method(provider);
+        } catch (e: unknown) {
+          handleError(e);
         }
       }
     }
+
     throw new RpcError(RpcError.reasons.FailedToSend, { errors });
   }
 

--- a/packages/adapters/txservice/src/aggregator.ts
+++ b/packages/adapters/txservice/src/aggregator.ts
@@ -715,9 +715,11 @@ export class RpcProviderAggregator {
       const filteredResults: T[] = results.filter((item) => item !== undefined) as T[];
       if (filteredResults.length > 0) {
         // Pick the most common answer.
-        let counts: Map<T, number> = new Map();
+        let counts: Map<string, number> = new Map();
         counts = filteredResults.reduce((counts, item) => {
-          counts.set(item, (counts.get(item) ?? 0) + 1);
+          // Stringify the key. We'll convert it back before returning.
+          const key = JSON.stringify(item);
+          counts.set(key, (counts.get(key) ?? 0) + 1);
           return counts;
         }, counts);
         const maxCount = Math.max(...Array.from(counts.values()));
@@ -745,7 +747,13 @@ export class RpcProviderAggregator {
             },
           );
         }
-        return topResponses[0];
+        // We've been using string keys and need to convert back to the OG item type T.
+        const stringifiedTopResponse = topResponses[0];
+        for (const item of filteredResults) {
+          if (JSON.stringify(item) === stringifiedTopResponse) {
+            return item;
+          }
+        }
       }
     } else {
       // Shuffle the providers (with weighting towards better ones) and pick from the top.

--- a/packages/adapters/txservice/src/config.ts
+++ b/packages/adapters/txservice/src/config.ts
@@ -107,6 +107,10 @@ const CoreChainConfigSchema = Type.Object({
   // How often (ms) we will check all RPC providers to measure how in-sync they are with the blockchain.
   // By default, every 5 mins (5 * 60_000).
   syncProvidersInterval: Type.Integer(),
+  // Whether we want to maximize quorum/consensus from all available providers when we're doing read calls.
+  // Set this valueto `true` if it's critically important to maintain accurate responses from a number of providers that
+  // vary in quality. This will increase the number of RPC calls we're making overall, but guarantees accuracy.
+  quorum: Type.Optional(Type.Integer()),
 
   /// DEBUGGING / DEVELOPMENT
   // WARNING: Please do not alter these configuration values; they should be used for development and/or debugging

--- a/packages/adapters/txservice/src/shared/errors.ts
+++ b/packages/adapters/txservice/src/shared/errors.ts
@@ -21,6 +21,22 @@ export class StallTimeout extends NxtpError {
   }
 }
 
+export class QuorumNotMet extends NxtpError {
+  static readonly type = QuorumNotMet.name;
+
+  constructor(highestQuorum: number, requiredQuorum: number, public readonly context: any = {}) {
+    super(
+      `Required quorum for RPC provider responses was not met! Highest quorum: ${highestQuorum}; Required quorum: ${requiredQuorum}`,
+      {
+        ...context,
+        highestQuorum,
+        requiredQuorum,
+      },
+      QuorumNotMet.type,
+    );
+  }
+}
+
 export class RpcError extends NxtpError {
   static readonly type = RpcError.name;
 

--- a/packages/adapters/txservice/test/aggregator.spec.ts
+++ b/packages/adapters/txservice/test/aggregator.spec.ts
@@ -692,6 +692,21 @@ describe("RpcProviderAggregator", () => {
       expect(shuffleSyncedProvidersStub.callCount).to.equal(0);
     });
 
+    it("works with quorum > 1 and different return types", async () => {
+      // Quorum required = 2. The 2 good RPC providers we supplied should suffice.
+      (chainProvider as any).config.quorum = 2;
+
+      for (const returnValue of ["hello test", false, 12345, BigNumber.from("12345"), { hello: "test" }]) {
+        goodRpcProvider.method = Sinon.stub().resolves(returnValue);
+        badRpcProvider.method = Sinon.stub().rejects(testRpcError);
+
+        testSyncProviders = [goodRpcProvider, badRpcProvider, goodRpcProvider];
+        (chainProvider as any).providers = testSyncProviders;
+
+        expect(await (chainProvider as any).execute(false, mockMethodParam)).to.be.deep.eq(returnValue);
+      }
+    });
+
     it("should fail if quorum not met", async () => {
       testSyncProviders = [badRpcProvider, badRpcProvider, goodRpcProvider];
 

--- a/packages/agents/watcher/src/config.ts
+++ b/packages/agents/watcher/src/config.ts
@@ -7,6 +7,7 @@ import { Static, Type } from "@sinclair/typebox";
 export const TChainConfig = Type.Object({
   assets: Type.Array(TAssetDescription), // Assets for which the router provides liquidity on this chain.
   providers: Type.Array(Type.String()),
+  quorum: Type.Optional(Type.Integer()), // Required quorum among RPC providers.
 });
 
 export const WatcherConfigSchema = Type.Intersect([

--- a/packages/deployments/contracts/src/typechain-types/contracts/shared/libraries/index.ts
+++ b/packages/deployments/contracts/src/typechain-types/contracts/shared/libraries/index.ts
@@ -3,4 +3,7 @@
 /* eslint-disable */
 import type * as multisendSol from "./Multisend.sol";
 export type { multisendSol };
+import type * as unwrapperSol from "./Unwrapper.sol";
+export type { unwrapperSol };
+export type { Orphanage } from "./Orphanage";
 export type { TypedMemView } from "./TypedMemView";

--- a/packages/deployments/contracts/src/typechain-types/factories/contracts/shared/libraries/index.ts
+++ b/packages/deployments/contracts/src/typechain-types/factories/contracts/shared/libraries/index.ts
@@ -2,4 +2,6 @@
 /* tslint:disable */
 /* eslint-disable */
 export * as multisendSol from "./Multisend.sol";
+export * as unwrapperSol from "./Unwrapper.sol";
+export { Orphanage__factory } from "./Orphanage__factory";
 export { TypedMemView__factory } from "./TypedMemView__factory";

--- a/packages/deployments/contracts/src/typechain-types/index.ts
+++ b/packages/deployments/contracts/src/typechain-types/index.ts
@@ -276,8 +276,12 @@ export type { IProposedOwnable } from "./contracts/shared/interfaces/IProposedOw
 export { IProposedOwnable__factory } from "./factories/contracts/shared/interfaces/IProposedOwnable__factory";
 export type { MultiSend } from "./contracts/shared/libraries/Multisend.sol/MultiSend";
 export { MultiSend__factory } from "./factories/contracts/shared/libraries/Multisend.sol/MultiSend__factory";
+export type { Orphanage } from "./contracts/shared/libraries/Orphanage";
+export { Orphanage__factory } from "./factories/contracts/shared/libraries/Orphanage__factory";
 export type { TypedMemView } from "./contracts/shared/libraries/TypedMemView";
 export { TypedMemView__factory } from "./factories/contracts/shared/libraries/TypedMemView__factory";
+export type { Wrapper } from "./contracts/shared/libraries/Unwrapper.sol/Wrapper";
+export { Wrapper__factory } from "./factories/contracts/shared/libraries/Unwrapper.sol/Wrapper__factory";
 export type { ProposedOwnable } from "./contracts/shared/ProposedOwnable";
 export { ProposedOwnable__factory } from "./factories/contracts/shared/ProposedOwnable__factory";
 export type { ProposedOwnableUpgradeable } from "./contracts/shared/ProposedOwnableUpgradeable";


### PR DESCRIPTION
## Description

Now we can specify a quorum (consensus) must be met in order to validate returned values from providers.

When a quorum is specified, we go from being stringent/economical with our RPC requests to a mode where we consult all available RPC providers and require that at least Q providers agree on a return value for the request, where Q is the configured quorum.

An unconfigured quorum or a quorum value of 1 means we continue using the provider shuffling and only consult 1 provider at a time until we get a response.

Having a quorum is valuable for agents that need maximum accuracy to operate: namely watcher.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code
