### PR TITLE
Sdk decrease rpc calls

### DIFF
--- a/packages/agents/sdk/package.json
+++ b/packages/agents/sdk/package.json
@@ -8,7 +8,7 @@
     "dev": "yarn build --watch --preserveWatchOutput",
     "lint": "eslint ./src --ext .ts --env node",
     "test": "nyc ts-mocha --check-leaks --exit --timeout 120000 'test/**/*.spec.ts'",
-    "test-sdkbase": "nyc ts-mocha --check-leaks --exit --timeout 120000 'test/sdkPool.spec.ts'",
+    "test-sdkbase": "nyc ts-mocha --check-leaks --exit --timeout 120000 'test/sdkBase.spec.ts'",
     "clean": "rimraf ./dist ./tsconfig.tsBuildInfo",
     "build": "tsc --build ./tsconfig.build.json",
     "verify": "yarn test && yarn clean && yarn build && yarn lint --max-warnings 0",

--- a/packages/agents/sdk/src/sdkPool.ts
+++ b/packages/agents/sdk/src/sdkPool.ts
@@ -702,22 +702,25 @@ export class SdkPool extends SdkShared {
    * }
    * ```
    */
-  async getPoolData(params: { key?: string; domainId?: string; lpTokenAddress?: string }): Promise<any> {
-    const { key, domainId, lpTokenAddress } = params;
+  getPoolData = memoize(
+    async (params: { key?: string; domainId?: string; lpTokenAddress?: string }): Promise<any> => {
+      const { key, domainId, lpTokenAddress } = params;
 
-    const poolIdentifier = key ? `key=eq.${key}&` : "";
-    const domainIdentifier = domainId ? `domain=eq.${domainId}&` : "";
-    const lpTokenIdentifier = lpTokenAddress ? `lp_token=eq.${lpTokenAddress}&` : "";
+      const poolIdentifier = key ? `key=eq.${key}&` : "";
+      const domainIdentifier = domainId ? `domain=eq.${domainId}&` : "";
+      const lpTokenIdentifier = lpTokenAddress ? `lp_token=eq.${lpTokenAddress}&` : "";
 
-    const uri = formatUrl(
-      this.config.cartographerUrl!,
-      "stableswap_pools?",
-      poolIdentifier + domainIdentifier + lpTokenIdentifier,
-    );
-    validateUri(uri);
+      const uri = formatUrl(
+        this.config.cartographerUrl!,
+        "stableswap_pools?",
+        poolIdentifier + domainIdentifier + lpTokenIdentifier,
+      );
+      validateUri(uri);
 
-    return await axiosGetRequest(uri);
-  }
+      return await axiosGetRequest(uri);
+    },
+    { promise: true, maxAge: 5 * 60 * 1000 }, // 5 min
+  );
 
   // ------------------- Pool Operations ------------------- //
 
@@ -1181,42 +1184,45 @@ export class SdkPool extends SdkShared {
    * }
    * ```
    */
-  async getHourlySwapVolume(params: {
-    key?: string;
-    domainId?: string;
-    startTimestamp?: number;
-    endTimestamp?: number;
-    range?: { limit?: number; offset?: number };
-  }): Promise<any> {
-    const { key, domainId, startTimestamp, endTimestamp, range } = params;
+  getHourlySwapVolume = memoize(
+    async (params: {
+      key?: string;
+      domainId?: string;
+      startTimestamp?: number;
+      endTimestamp?: number;
+      range?: { limit?: number; offset?: number };
+    }): Promise<any> => {
+      const { key, domainId, startTimestamp, endTimestamp, range } = params;
 
-    const poolIdentifier = key ? `pool_id=eq.${key.toLowerCase()}&` : "";
-    const domainIdentifier = domainId ? `domain=eq.${domainId}&` : "";
+      const poolIdentifier = key ? `pool_id=eq.${key.toLowerCase()}&` : "";
+      const domainIdentifier = domainId ? `domain=eq.${domainId}&` : "";
 
-    const limit = range?.limit ? range.limit : 10;
-    const offset = range?.offset ? range.offset : 0;
+      const limit = range?.limit ? range.limit : 10;
+      const offset = range?.offset ? range.offset : 0;
 
-    const millis = 1000;
-    const start = startTimestamp ? new Date(startTimestamp * millis).toISOString() : undefined;
-    const end = endTimestamp ? new Date(endTimestamp * millis).toISOString() : undefined;
-    const startTimestampIdentifier = start ? `swap_hour=gt.${start}&` : "";
-    const endTimestampIdentifier = end ? `swap_hour=lt.${end}&` : "";
+      const millis = 1000;
+      const start = startTimestamp ? new Date(startTimestamp * millis).toISOString() : undefined;
+      const end = endTimestamp ? new Date(endTimestamp * millis).toISOString() : undefined;
+      const startTimestampIdentifier = start ? `swap_hour=gt.${start}&` : "";
+      const endTimestampIdentifier = end ? `swap_hour=lt.${end}&` : "";
 
-    const rangeIdentifier = `limit=${limit}&offset=${offset}&`;
-    const orderIdentifier = `order=swap_hour.desc`;
+      const rangeIdentifier = `limit=${limit}&offset=${offset}&`;
+      const orderIdentifier = `order=swap_hour.desc`;
 
-    const uri = formatUrl(
-      this.config.cartographerUrl!,
-      "hourly_swap_volume?",
-      poolIdentifier +
-        startTimestampIdentifier +
-        endTimestampIdentifier +
-        domainIdentifier +
-        rangeIdentifier +
-        orderIdentifier,
-    );
-    validateUri(uri);
+      const uri = formatUrl(
+        this.config.cartographerUrl!,
+        "hourly_swap_volume?",
+        poolIdentifier +
+          startTimestampIdentifier +
+          endTimestampIdentifier +
+          domainIdentifier +
+          rangeIdentifier +
+          orderIdentifier,
+      );
+      validateUri(uri);
 
-    return await axiosGetRequest(uri);
-  }
+      return await axiosGetRequest(uri);
+    },
+    { promise: true, maxAge: 5 * 60 * 1000 }, // 5 min
+  );
 }

--- a/packages/agents/sdk/src/sdkPool.ts
+++ b/packages/agents/sdk/src/sdkPool.ts
@@ -302,19 +302,14 @@ export class SdkPool extends SdkShared {
     ]);
     const key = this.calculateCanonicalKey(canonicalDomain, canonicalId);
 
-    const [tokenIndexFrom, tokenIndexTo] = await Promise.all([
-      connextContract.getSwapTokenIndex(key, _tokenX),
-      connextContract.getSwapTokenIndex(key, _tokenY),
+    const [tokenXIndex, tokenYIndex, tokenXDecimals, tokenYDecimals] = await Promise.all([
+      this.getPoolTokenIndex(domainId, _tokenX, _tokenX),
+      this.getPoolTokenIndex(domainId, _tokenX, _tokenY),
+      this.getPoolTokenDecimals(domainId, _tokenX, _tokenX),
+      this.getPoolTokenDecimals(domainId, _tokenX, _tokenY),
     ]);
 
-    const [tokenXContract, tokenYContract] = await Promise.all([
-      this.getERC20(domainId, _tokenX),
-      this.getERC20(domainId, _tokenY),
-    ]);
-
-    const [tokenXDecimals, tokenYDecimals] = await Promise.all([tokenXContract.decimals(), tokenYContract.decimals()]);
-
-    const amountY = await connextContract.calculateSwap(key, tokenIndexFrom, tokenIndexTo, amountX);
+    const amountY = await connextContract.calculateSwap(key, tokenXIndex, tokenYIndex, amountX);
 
     return this.calculatePriceImpact(
       BigNumber.from(amountX).mul(BigNumber.from(10).pow(18 - tokenXDecimals)),
@@ -492,6 +487,27 @@ export class SdkPool extends SdkShared {
     if (pool) {
       if (pool.local.address === _poolTokenAddress) return pool.local.index;
       else if (pool.adopted.address === _poolTokenAddress) return pool.adopted.index;
+    }
+
+    return -1;
+  }
+
+  /**
+   * Reads the decimal precision of a token in a pool.
+   *
+   * @param domainId - The domain id of the pool.
+   * @param tokenAddress - The address of local or adopted token.
+   * @param poolTokenAddress - The address of the token in the pool to get the precision for.
+   * @returns The decimal precision of the specified token in the pool or -1 if not found.
+   */
+  async getPoolTokenDecimals(domainId: string, tokenAddress: string, poolTokenAddress: string): Promise<number> {
+    const _tokenAddress = utils.getAddress(tokenAddress);
+    const _poolTokenAddress = utils.getAddress(poolTokenAddress);
+    const pool = await this.getPool(domainId, _tokenAddress);
+
+    if (pool) {
+      if (pool.local.address === _poolTokenAddress) return pool.local.decimals;
+      else if (pool.adopted.address === _poolTokenAddress) return pool.adopted.decimals;
     }
 
     return -1;

--- a/packages/agents/sdk/src/sdkShared.ts
+++ b/packages/agents/sdk/src/sdkShared.ts
@@ -188,13 +188,16 @@ export class SdkShared {
    * },
    * ```
    */
-  async getAssetsData(): Promise<AssetData[]> {
-    const uri = formatUrl(this.config.cartographerUrl!, "assets");
-    // Validate uri
-    validateUri(uri);
+  getAssetsData = memoize(
+    async (): Promise<AssetData[]> => {
+      const uri = formatUrl(this.config.cartographerUrl!, "assets");
+      // Validate uri
+      validateUri(uri);
 
-    return await axiosGetRequest(uri);
-  }
+      return await axiosGetRequest(uri);
+    },
+    { promise: true, maxAge: 5 * 60 * 1000 }, // 5 min
+  );
 
   /**
    * Fetches the list of supported networks and assets.

--- a/packages/agents/sdk/test/sdkPool.spec.ts
+++ b/packages/agents/sdk/test/sdkPool.spec.ts
@@ -117,6 +117,7 @@ describe("SdkPool", () => {
       expect(sdkPool.getTokenSupply).to.be.a("function");
       expect(sdkPool.getTokenUserBalance).to.be.a("function");
       expect(sdkPool.getPoolTokenIndex).to.be.a("function");
+      expect(sdkPool.getPoolTokenDecimals).to.be.a("function");
       expect(sdkPool.getPoolTokenBalance).to.be.a("function");
       expect(sdkPool.getPoolTokenAddress).to.be.a("function");
       expect(sdkPool.getVirtualPrice).to.be.a("function");

--- a/packages/agents/sdk/test/sdkUtils.spec.ts
+++ b/packages/agents/sdk/test/sdkUtils.spec.ts
@@ -71,12 +71,6 @@ describe("SdkUtils", () => {
 
       expect(res).to.not.be.undefined;
     });
-
-    it("should error if validateUri fails", async () => {
-      (nxtpUtils as any).config.cartographerUrl = "invalidUrl";
-
-      await expect(nxtpUtils.getAssetsData()).to.be.rejectedWith(UriInvalid);
-    });
   });
 
   describe("#getTransfers", () => {


### PR DESCRIPTION
## Description

`calculateSwapPriceImpact` was reading token decimals from contract. Since this data is saved in the pool object already, we don't need this extraneous rpc call.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [x] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
