### PR TITLE
fix: increase limit when finding associated root messages

### DIFF
--- a/packages/adapters/database/src/client.ts
+++ b/packages/adapters/database/src/client.ts
@@ -856,7 +856,7 @@ export const getMessageRootsFromIndex = async (
     s.root_messages.Selectable[]
   >`select * from ${"root_messages"} where ${{
     spoke_domain,
-  }} and ${{ leaf_count: dc.gte(index) }} order by ${"leaf_count"} asc nulls last limit 10`.run(poolToUse);
+  }} and ${{ leaf_count: dc.gte(index) }} order by ${"leaf_count"} asc nulls last limit 75`.run(poolToUse);
   return root.length > 0 ? root.map(convertFromDbRootMessage) : [];
 };
 

--- a/packages/agents/cartographer/poller/src/lib/operations/messagestatus.ts
+++ b/packages/agents/cartographer/poller/src/lib/operations/messagestatus.ts
@@ -64,7 +64,9 @@ export const getMessageStatus = async (transfer: XTransfer): Promise<XTransferMe
 
   // A message root from the spoke domain got arrived at the hub domain successfully
   let aggregateRoot: string | undefined = undefined;
-  for (const rootMessage of rootMessages) {
+  // iterate through roots with most highes leaf count first (most likely to have aggregate when system
+  // is under load)
+  for (const rootMessage of rootMessages.sort((a, b) => b.count - a.count)) {
     aggregateRoot = await database.getAggregateRoot(rootMessage.root);
     if (aggregateRoot) break;
   }


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Many reconciled messages have the status `SpokeRootArrivedOnHub`. Under load, limiting the `root_messages` query to 10 means many messages will not find an associated aggregate root.

This is not a sustainable change, but this problem is currently impacting production testnet instances. (see transfer `0x717a71dad3c2948f154fb1f78f29c0ab9d2cd0886faa290ff7ff83d540f62109`)

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
