### PR TITLE
Fix next fee estimation

### DIFF
--- a/packages/agents/sequencer/src/lib/errors/relayer.ts
+++ b/packages/agents/sequencer/src/lib/errors/relayer.ts
@@ -17,3 +17,9 @@ export class SlippageToleranceExceeded extends NxtpError {
     super(`Slippage tolerance exceeded`, context, SlippageToleranceExceeded.name);
   }
 }
+
+export class CanonicalAssetNotFound extends NxtpError {
+  constructor(context: any = {}) {
+    super(`Asset not found`, context, CanonicalAssetNotFound.name);
+  }
+}

--- a/packages/agents/sequencer/src/lib/helpers/relayerfee.ts
+++ b/packages/agents/sequencer/src/lib/helpers/relayerfee.ts
@@ -1,8 +1,15 @@
-import { XTransfer, createLoggingContext, domainToChainId } from "@connext/nxtp-utils";
+import {
+  RequestContextWithTransactionId,
+  XTransfer,
+  createLoggingContext,
+  domainToChainId,
+  evmId,
+} from "@connext/nxtp-utils";
 import { BigNumber, constants } from "ethers";
 
 import { calculateRelayerFee, safeGetConversionRate, getDecimalsForAsset } from "../../mockable";
 import { getContext } from "../../sequencer";
+import { CanonicalAssetNotFound } from "../errors";
 
 /**
  * @dev Relayer fee paid by user would be checked whether its enough or not
@@ -51,34 +58,80 @@ export const canSubmitToRelayer = async (transfer: XTransfer): Promise<{ canSubm
   );
 
   let relayerFeePaidUsd = constants.Zero;
-  const originChainId = domainToChainId(+originDomain);
-  // origin native token to usdc
-  const prices: Record<string, number> = {};
-  prices[constants.AddressZero] = await safeGetConversionRate(originChainId, undefined, logger);
-  for (const asset of relayerFeeAssets) {
-    if (asset === constants.AddressZero) {
-      const nativeFee = BigNumber.from(origin.relayerFees[asset]);
-      const relayerFeePaid = nativeFee.mul(Math.floor(prices[asset] * 1000)).div(1000);
-      relayerFeePaidUsd = relayerFeePaidUsd.add(relayerFeePaid);
-    } else if (asset.toLowerCase() === origin.assets.transacting.asset.toLowerCase()) {
-      // origin native token to asset price
-      // get adopted asset for the origin domain
-      let adoptedAsset = asset;
-      if (origin.assets.transacting.asset.toLowerCase() === origin.assets.bridged.asset.toLowerCase()) {
-        adoptedAsset = await getOriginAdoptedAsset(originDomain, origin.assets.bridged.asset);
-      }
-      const originPriceAsset = await getConversionRate(originChainId, adoptedAsset, logger);
 
-      prices[asset] = originPriceAsset === 0 ? 0 : prices[constants.AddressZero] / originPriceAsset;
-      const relayerFeeDecimals = await getDecimalsForAsset(asset, originChainId, undefined, chainData, () =>
-        chainreader.getDecimalsForAsset(+originDomain, asset),
+  // Convert the amount of relayer fee for each asset into a corresponding USD value, and sum
+  // NOTE: `safeGetConversionRate` will give you the price of the native asset on the provided chain,
+  // to the provided asset (or USDC if not provided).
+
+  // Store all retrieved prices for easy logging
+  const prices: Record<string, number> = {};
+
+  // Get the price of native asset in USDC for conversions.
+  const originChainId = domainToChainId(+originDomain);
+  const originNativeAssetPrice = await safeGetConversionRate(originChainId, undefined, logger);
+  prices[constants.AddressZero] = originNativeAssetPrice;
+  for (const asset of relayerFeeAssets) {
+    // The relayer fee can technically be paid in any whitelisted asset, but will generally be
+    // one of the three options:
+    // - origin chain native asset
+    // - local asset (e.g. nextWETH)
+    // - adopted asset (e.g. WETH)
+    // where local / adopted assets are be the transacting asset on the origin chain.
+
+    // Get the price of the asset in USDC
+    // NOTE: when using the local asset, should get the price of the canonical counterpart
+    let assetPriceUsd;
+    if (asset.toLowerCase() === constants.AddressZero) {
+      assetPriceUsd = originNativeAssetPrice;
+    } else if (
+      asset.toLowerCase() === origin.assets.transacting.asset.toLowerCase() &&
+      origin.assets.transacting.asset.toLowerCase() === origin.assets.bridged.asset.toLowerCase()
+    ) {
+      logger.debug("Relayer fee is in local asset", requestContext, methodContext, {
+        asset,
+        local: origin.assets.bridged.asset,
+      });
+      // relayer fee is in transacting asset && transacting asset is the local asset.
+      // get the USD price of the canonical counterpart
+      const { canonicalAsset, canonicalChain } = await getCanonicalAssetAndChainFromLocal(
+        originDomain,
+        asset,
+        requestContext,
       );
-      const relayerFeePaid = BigNumber.from(origin.relayerFees[asset])
-        .mul(Math.floor(prices[asset] * 1000))
-        .div(1000)
-        .mul(BigNumber.from(10).pow(18 - relayerFeeDecimals));
-      relayerFeePaidUsd = relayerFeePaidUsd.add(relayerFeePaid);
+      // get the price of the native asset on canonical chain in USDC; and canonical asset in canonical native
+      const [canonicalNativeUsd, canonicalAssetCanonicalNative] = await Promise.all([
+        safeGetConversionRate(canonicalChain, undefined, logger),
+        safeGetConversionRate(canonicalChain, canonicalAsset, logger),
+      ]);
+      // NOTE: log here instead of at end because intermediate step could be helpful in deep dive, but only
+      // end calculations will be practically useful
+      logger.debug("Got canonical asset prices", requestContext, methodContext, {
+        asset,
+        canonicalAsset,
+        canonicalChain,
+        canonicalNativeUsd,
+        canonicalAssetCanonicalNative,
+      });
+      assetPriceUsd = canonicalNativeUsd === 0 ? 0 : canonicalAssetCanonicalNative / canonicalNativeUsd;
+    } else {
+      // otherwise it is the adopted (or unknown) asset, query the price of the asset directly
+      const assetPriceNative = await safeGetConversionRate(originChainId, asset, logger);
+      assetPriceUsd = assetPriceNative / originNativeAssetPrice;
     }
+    prices[asset] = assetPriceUsd;
+
+    // Get the decimals of the asset
+    const relayerFeeDecimals =
+      asset === constants.AddressZero
+        ? 18
+        : await getDecimalsForAsset(asset, originChainId, undefined, chainData, () =>
+            chainreader.getDecimalsForAsset(+originDomain, asset),
+          );
+    const relayerFeePaid = BigNumber.from(origin.relayerFees[asset])
+      .mul(Math.floor(assetPriceUsd * 1000))
+      .div(1000)
+      .mul(BigNumber.from(10).pow(18 - relayerFeeDecimals));
+    relayerFeePaidUsd = relayerFeePaidUsd.add(relayerFeePaid);
   }
 
   const minimumFeeNeeded = estimatedRelayerFeeUsd.mul(Math.floor(100 - config.relayerFeeTolerance)).div(100);
@@ -94,18 +147,37 @@ export const canSubmitToRelayer = async (transfer: XTransfer): Promise<{ canSubm
   return { canSubmit, needed: minimumFeeNeeded.toString() };
 };
 
-export const getOriginAdoptedAsset = async (_originDomain: string, _originLocalAsset: string): Promise<string> => {
+const getCanonicalAssetAndChainFromLocal = async (
+  _domain: string,
+  _local: string,
+  _requestContext: RequestContextWithTransactionId,
+): Promise<{ canonicalAsset: string; canonicalChain: number }> => {
   const {
+    logger,
     adapters: { subgraph },
   } = getContext();
-  // handle address(0) default case
-  if (_originLocalAsset === constants.AddressZero) {
-    return constants.AddressZero;
+  const { requestContext, methodContext } = createLoggingContext(
+    getCanonicalAssetAndChainFromLocal.name,
+    _requestContext,
+    _requestContext.id,
+  );
+  logger.debug("Method start", requestContext, methodContext, { domain: _domain, local: _local });
+
+  // get asset record from given domain/local asset combo
+  const sendingDomainAsset = await subgraph.getAssetByLocal(_domain, _local);
+  if (!sendingDomainAsset) {
+    throw new CanonicalAssetNotFound({ domain: _domain, local: _local });
   }
 
-  // get canonical asset from orgin domain.
-  const sendingDomainAsset = await subgraph.getAssetByLocal(_originDomain, _originLocalAsset);
-  const adopterAsset = sendingDomainAsset!.adoptedAsset;
+  const canonicalAsset = evmId(sendingDomainAsset.canonicalId);
+  const canonicalChain = domainToChainId(+sendingDomainAsset.canonicalDomain);
 
-  return adopterAsset;
+  logger.debug("Method complete", requestContext, methodContext, {
+    domain: _domain,
+    local: _local,
+    canonicalAsset,
+    canonicalChain,
+  });
+
+  return { canonicalAsset, canonicalChain };
 };

--- a/packages/agents/sequencer/src/lib/helpers/relayerfee.ts
+++ b/packages/agents/sequencer/src/lib/helpers/relayerfee.ts
@@ -62,8 +62,14 @@ export const canSubmitToRelayer = async (transfer: XTransfer): Promise<{ canSubm
       relayerFeePaidUsd = relayerFeePaidUsd.add(relayerFeePaid);
     } else if (asset.toLowerCase() === origin.assets.transacting.asset.toLowerCase()) {
       // origin native token to asset price
-      const originNativePriceAsset = await safeGetConversionRate(originChainId, asset, logger);
-      prices[asset] = originNativePriceAsset === 0 ? 0 : prices[constants.AddressZero] / originNativePriceAsset;
+      // get adopted asset for the origin domain
+      let adoptedAsset = asset;
+      if (origin.assets.transacting.asset.toLowerCase() === origin.assets.bridged.asset.toLowerCase()) {
+        adoptedAsset = await getOriginAdoptedAsset(originDomain, origin.assets.bridged.asset);
+      }
+      const originPriceAsset = await getConversionRate(originChainId, adoptedAsset, logger);
+
+      prices[asset] = originPriceAsset === 0 ? 0 : prices[constants.AddressZero] / originPriceAsset;
       const relayerFeeDecimals = await getDecimalsForAsset(asset, originChainId, undefined, chainData, () =>
         chainreader.getDecimalsForAsset(+originDomain, asset),
       );
@@ -86,4 +92,20 @@ export const canSubmitToRelayer = async (transfer: XTransfer): Promise<{ canSubm
   });
 
   return { canSubmit, needed: minimumFeeNeeded.toString() };
+};
+
+export const getOriginAdoptedAsset = async (_originDomain: string, _originLocalAsset: string): Promise<string> => {
+  const {
+    adapters: { subgraph },
+  } = getContext();
+  // handle address(0) default case
+  if (_originLocalAsset === constants.AddressZero) {
+    return constants.AddressZero;
+  }
+
+  // get canonical asset from orgin domain.
+  const sendingDomainAsset = await subgraph.getAssetByLocal(_originDomain, _originLocalAsset);
+  const adopterAsset = sendingDomainAsset!.adoptedAsset;
+
+  return adopterAsset;
 };

--- a/packages/agents/sequencer/test/lib/helpers/relayerfee.spec.ts
+++ b/packages/agents/sequencer/test/lib/helpers/relayerfee.spec.ts
@@ -1,4 +1,4 @@
-import { ChainData, expect, getRandomBytes32, Logger, mkAddress, OriginTransfer } from "@connext/nxtp-utils";
+import { canonizeId, ChainData, expect, Logger, mkAddress, OriginTransfer } from "@connext/nxtp-utils";
 import { BigNumber, constants } from "ethers";
 import { stub, restore, reset, SinonStub } from "sinon";
 
@@ -11,6 +11,8 @@ import { Provider } from "@ethersproject/abstract-provider";
 
 describe("Helpers:RelayerFee", () => {
   describe("#canSubmitToRelayer", () => {
+    let adoptedAsset: string;
+    let localAsset: string;
     let safeCalculateRelayerFeeStub: SinonStub;
     let safeGetConversionRateStub: SinonStub<
       [_chainId: number, to?: string | undefined, logger?: Logger | undefined],
@@ -26,13 +28,19 @@ describe("Helpers:RelayerFee", () => {
       Promise<number>
     >;
     beforeEach(() => {
+      localAsset = mkAddress("0xccc");
+      adoptedAsset = mkAddress("0xddd");
       safeCalculateRelayerFeeStub = stub(MockableFns, "calculateRelayerFee");
       safeGetConversionRateStub = stub(MockableFns, "safeGetConversionRate").resolves(1000);
       getDecimalsForAssetStub = stub(MockableFns, "getDecimalsForAsset").resolves(6);
-      (ctxMock.adapters.subgraph as any).getAssetByLocal.resolves({
-        canonicalId: getRandomBytes32(),
-        canonicalDomain: 133712,
-      });
+      (ctxMock.adapters.subgraph as any).getAssets.resolves([
+        {
+          adoptedAsset,
+          localAsset,
+          canonicalId: canonizeId(localAsset),
+          canonicalDomain: 133712,
+        },
+      ]);
     });
 
     afterEach(() => {
@@ -65,11 +73,20 @@ describe("Helpers:RelayerFee", () => {
       expect(res).to.be.deep.eq({ canSubmit: true, needed: "80" });
     });
 
-    it("should return true if relayer fee is enough USD only, 6 decimals", async () => {
-      const transactingAsset = mkAddress("0xaaa");
+    it("should return true if relayer fee is enough USD only, 6 decimals, local asset", async () => {
       const transfer = mock.entity.xtransfer({
-        relayerFees: { [transactingAsset]: "1" },
-        asset: transactingAsset,
+        relayerFees: { [localAsset]: "1" },
+        asset: localAsset,
+      }) as OriginTransfer;
+      safeCalculateRelayerFeeStub.resolves(BigNumber.from("1000000000000"));
+      const res = await canSubmitToRelayer(transfer);
+      expect(res).to.be.deep.eq({ canSubmit: true, needed: "800000000000" });
+    });
+
+    it("should return true if relayer fee is enough USD only, 6 decimals, adopted asset", async () => {
+      const transfer = mock.entity.xtransfer({
+        relayerFees: { [adoptedAsset]: "1" },
+        asset: adoptedAsset,
       }) as OriginTransfer;
       safeCalculateRelayerFeeStub.resolves(BigNumber.from("1000000000000"));
       const res = await canSubmitToRelayer(transfer);
@@ -81,10 +98,9 @@ describe("Helpers:RelayerFee", () => {
       getDecimalsForAssetStub.resolves(18);
       safeGetConversionRateStub.onCall(0).resolves(0.9992302253800343); // 1 XDAI = 1 USD
       safeGetConversionRateStub.onCall(1).resolves(0.0005429445181187423); // $1 = 0.0054 ETH ($1,840.35)
-      const transactingAsset = mkAddress("0xaaa");
       const transfer = mock.entity.xtransfer({
-        relayerFees: { [constants.AddressZero]: "184095455962097", [transactingAsset]: "525094043977850" },
-        asset: transactingAsset,
+        relayerFees: { [constants.AddressZero]: "184095455962097", [adoptedAsset]: "525094043977850" },
+        asset: adoptedAsset,
       }) as OriginTransfer;
       safeCalculateRelayerFeeStub.resolves(BigNumber.from("163985699539200000"));
       const res = await canSubmitToRelayer(transfer);
@@ -93,7 +109,7 @@ describe("Helpers:RelayerFee", () => {
 
     it("should return false if relayerFee isn't enough USD", async () => {
       getDecimalsForAssetStub.resolves(18);
-      const transfer = mock.entity.xtransfer({ relayerFees: { [mkAddress("0xaaa")]: "79" } }) as OriginTransfer;
+      const transfer = mock.entity.xtransfer({ relayerFees: { [adoptedAsset]: "79" } }) as OriginTransfer;
       safeCalculateRelayerFeeStub.resolves(BigNumber.from("100"));
       const res = await canSubmitToRelayer(transfer);
       expect(res).to.be.deep.eq({ canSubmit: false, needed: "80" });
@@ -108,7 +124,7 @@ describe("Helpers:RelayerFee", () => {
 
     it("should return false if relayerFee isn't enough both", async () => {
       const transfer = mock.entity.xtransfer({
-        relayerFees: { [constants.AddressZero]: "3", [mkAddress("0xaaa")]: "8" },
+        relayerFees: { [constants.AddressZero]: "3", [localAsset]: "8" },
       }) as OriginTransfer;
       safeCalculateRelayerFeeStub.resolves(BigNumber.from("10000000004004"));
       const res = await canSubmitToRelayer(transfer);

--- a/packages/agents/sequencer/test/lib/helpers/relayerfee.spec.ts
+++ b/packages/agents/sequencer/test/lib/helpers/relayerfee.spec.ts
@@ -2,6 +2,7 @@ import { ChainData, expect, Logger, mkAddress, OriginTransfer } from "@connext/n
 import { BigNumber, constants } from "ethers";
 import { stub, restore, reset, SinonStub } from "sinon";
 
+import { ctxMock } from "../../globalTestHook";
 import { mock } from "../../mock";
 
 import * as MockableFns from "../../../src/mockable";
@@ -28,6 +29,7 @@ describe("Helpers:RelayerFee", () => {
       safeCalculateRelayerFeeStub = stub(MockableFns, "calculateRelayerFee");
       safeGetConversionRateStub = stub(MockableFns, "safeGetConversionRate").resolves(1000);
       getDecimalsForAssetStub = stub(MockableFns, "getDecimalsForAsset").resolves(6);
+      (ctxMock.adapters.subgraph as any).getAssetByLocal.resolves({ adoptedAsset: "0x456" });
     });
 
     afterEach(() => {

--- a/packages/agents/sequencer/test/lib/helpers/relayerfee.spec.ts
+++ b/packages/agents/sequencer/test/lib/helpers/relayerfee.spec.ts
@@ -1,4 +1,4 @@
-import { ChainData, expect, Logger, mkAddress, OriginTransfer } from "@connext/nxtp-utils";
+import { ChainData, expect, getRandomBytes32, Logger, mkAddress, OriginTransfer } from "@connext/nxtp-utils";
 import { BigNumber, constants } from "ethers";
 import { stub, restore, reset, SinonStub } from "sinon";
 
@@ -29,7 +29,10 @@ describe("Helpers:RelayerFee", () => {
       safeCalculateRelayerFeeStub = stub(MockableFns, "calculateRelayerFee");
       safeGetConversionRateStub = stub(MockableFns, "safeGetConversionRate").resolves(1000);
       getDecimalsForAssetStub = stub(MockableFns, "getDecimalsForAsset").resolves(6);
-      (ctxMock.adapters.subgraph as any).getAssetByLocal.resolves({ adoptedAsset: "0x456" });
+      (ctxMock.adapters.subgraph as any).getAssetByLocal.resolves({
+        canonicalId: getRandomBytes32(),
+        canonicalDomain: 133712,
+      });
     });
 
     afterEach(() => {

--- a/packages/deployments/contracts/src/domain.ts
+++ b/packages/deployments/contracts/src/domain.ts
@@ -47,27 +47,6 @@ export function canonizeId(data?: utils.BytesLike): Uint8Array {
 }
 
 /**
- * Converts an ID of 20 or 32 bytes to the corresponding EVM Address.
- *
- * For 32-byte IDs this enforces the EVM convention of using the LAST 20 bytes.
- *
- * @param data The data to truncate
- * @returns A 20-byte, 0x-prepended hex string representing the EVM Address
- * @throws if the data is not 20 or 32 bytes
- */
-export function evmId(data: utils.BytesLike): Address {
-  const u8a = utils.arrayify(data);
-
-  if (u8a.length === 32) {
-    return utils.hexlify(u8a.slice(12, 32));
-  } else if (u8a.length === 20) {
-    return utils.hexlify(u8a);
-  } else {
-    throw new Error(`Invalid id length. expected 20 or 32. Got ${u8a.length}`);
-  }
-}
-
-/**
  * Sleep async for some time.
  *
  * @param ms the number of milliseconds to sleep

--- a/packages/utils/src/helpers/hex.ts
+++ b/packages/utils/src/helpers/hex.ts
@@ -109,3 +109,24 @@ export function canonizeId(data?: utils.BytesLike): Uint8Array {
   }
   return utils.zeroPad(buf, 32);
 }
+
+/**
+ * Converts an ID of 20 or 32 bytes to the corresponding EVM Address.
+ *
+ * For 32-byte IDs this enforces the EVM convention of using the LAST 20 bytes.
+ *
+ * @param data The data to truncate
+ * @returns A 20-byte, 0x-prepended hex string representing the EVM Address
+ * @throws if the data is not 20 or 32 bytes
+ */
+export function evmId(data: utils.BytesLike): string {
+  const u8a = utils.arrayify(data);
+
+  if (u8a.length === 32) {
+    return utils.hexlify(u8a.slice(12, 32));
+  } else if (u8a.length === 20) {
+    return utils.hexlify(u8a);
+  } else {
+    throw new Error(`Invalid id length. expected 20 or 32. Got ${u8a.length}`);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15555,7 +15555,7 @@ __metadata:
     yargs-parser: ^16.1.0
   bin:
     gluegun: bin/gluegun
-  checksum: 20c10d1856a091b825c3f89d5277c69673aa410776275c83116fcae5c75da6e4555e7447157bee975b78fb61c84a8db73fd844ab2f433319b684e23aebdb61bc
+  checksum: 71abe7f31555f169a47510675596f79193c8f55e4beeb4e6efa06c22d41988fa9c747d5e398af7f8401cca22c08ffb7a6d57b03d764c14858513c9eba23b53b8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Uses pricing of canonical asset any time fees are paid in local or adopted. This is because gelato will not support next assets on their API, and have inconsistent asset support across chains (i.e. mainnet DAI is okay, but BSC DAI is not supported).

Currently blocking execution of transfers where users have paid in these assets.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes (hopefully) #4140  / #4152 

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
