### PR TITLE
Paginate reading pending txs from the redis cache

### DIFF
--- a/packages/adapters/cache/src/lib/caches/transfers.ts
+++ b/packages/adapters/cache/src/lib/caches/transfers.ts
@@ -204,8 +204,9 @@ export class TransfersCache extends Cache {
    *
    * @param domain - Domain to get pending transfers for.
    */
-  public async getPending(domain: string): Promise<string[]> {
-    return JSON.parse((await this.data.hget(`${this.prefix}:pending`, domain)) ?? "[]");
+  public async getPending(domain: string, offset = 0, limit = 100): Promise<string[]> {
+    const transferIds = await this.data.lrange(`${this.prefix}:pending:${domain}`, offset, offset + limit - 1);
+    return transferIds;
   }
 
   /**
@@ -215,10 +216,7 @@ export class TransfersCache extends Cache {
    * @param transferId - The transfer ID to add to the list of pending transfers.
    */
   private async addPending(domain: string, transferId: string) {
-    const currentPending = await this.getPending(domain);
-    if (!currentPending.includes(transferId)) {
-      await this.data.hset(`${this.prefix}:pending`, domain, JSON.stringify([...currentPending, transferId]));
-    }
+    await this.data.rpush(`${this.prefix}:pending:${domain}`, transferId);
   }
 
   /**
@@ -230,14 +228,9 @@ export class TransfersCache extends Cache {
    * list of pending transfers.
    */
   private async removePending(domain: string, transferId: string): Promise<boolean> {
-    const currentPending = await this.getPending(domain);
-    const index = currentPending.findIndex((id) => id === transferId);
-    if (index >= 0) {
-      currentPending.splice(index, 1);
-      await this.data.hset(`${this.prefix}:pending`, domain, JSON.stringify(currentPending));
-      return true;
-    }
-    return false;
+    const res = await this.data.lrem(`${this.prefix}:pending:${domain}`, 0, transferId);
+    if (res > 0) return true;
+    else return false;
   }
 
   /// MARK - Errors

--- a/packages/adapters/cache/src/lib/caches/transfers.ts
+++ b/packages/adapters/cache/src/lib/caches/transfers.ts
@@ -279,11 +279,11 @@ export class TransfersCache extends Cache {
    */
   public async setBidStatus(transferId: string): Promise<number> {
     const currentBid = await this.getBidStatus(transferId);
-    const attempt = currentBid ? (currentBid.attempts >= 1 ? currentBid.attempts + 1 : 1) : 1;
+    const attempts = currentBid ? (currentBid.attempts >= 1 ? currentBid.attempts + 1 : 1) : 1;
+    const timestamp = currentBid ? currentBid.timestamp : getNtpTimeSeconds().toString();
     const currrentStatus: BidStatus = {
-      // Update the timestamp to current time
-      timestamp: getNtpTimeSeconds().toString(),
-      attempts: attempt,
+      timestamp,
+      attempts,
     };
     return await this.data.hset(`${this.prefix}:status`, transferId, JSON.stringify(currrentStatus));
   }

--- a/packages/agents/router/src/tasks/publisher/operations/retryXCalls.ts
+++ b/packages/agents/router/src/tasks/publisher/operations/retryXCalls.ts
@@ -36,7 +36,8 @@ export const retryXCalls = async (): Promise<void> => {
     const pageSize = 100;
     let done = false;
     while (!done) {
-      const pending = await cache.transfers.getPending(domain, offset, pageSize);
+      const _pending = await cache.transfers.getPending(domain, offset, pageSize);
+      const pending = shuffle(_pending);
       logger.debug(`Getting pending transfers from the cache for domain: ${domain}`, requestContext, methodContext, {
         domain,
         offset,

--- a/packages/agents/router/src/tasks/publisher/operations/retryXCalls.ts
+++ b/packages/agents/router/src/tasks/publisher/operations/retryXCalls.ts
@@ -3,6 +3,7 @@ import { createLoggingContext, jsonifyError, OriginTransfer, getNtpTimeSeconds, 
 import { MQ_EXCHANGE, XCALL_MESSAGE_TYPE, XCALL_QUEUE } from "../../../setup";
 import { getContext } from "../publisher";
 
+const DEFAULT_EXECUTION_WINDOW = 4 * 60; // The average execution window is 4mins
 // Shuffle the input array in place
 // Algorithm: https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
 const shuffle = (input: string[]): string[] => {
@@ -56,7 +57,8 @@ export const retryXCalls = async (): Promise<void> => {
               if (bidStatus !== undefined) {
                 const startTime = Number(bidStatus.timestamp);
                 const elapsedTime = getNtpTimeSeconds() - startTime;
-                const waitTime = Math.pow(2, bidStatus.attempts);
+                // Retries every 2^n x 4min.
+                const waitTime = DEFAULT_EXECUTION_WINDOW * Math.pow(2, bidStatus.attempts - 1);
                 if (elapsedTime > waitTime) {
                   return transfer;
                 }

--- a/packages/agents/router/test/publisher/operations/retryXCalls.spec.ts
+++ b/packages/agents/router/test/publisher/operations/retryXCalls.spec.ts
@@ -97,6 +97,7 @@ describe("Operations:retryXCalls", () => {
 
     it("should work if pending set is empty", async () => {
       (mockPubContext.adapters.cache.transfers.getPending as SinonStub).resolves([]);
+      (mockPubContext.adapters.subgraph.getOriginTransfersByDomain as SinonStub).resolves([]);
       await expect(retryXCalls()).to.be.fulfilled;
 
       expect((mockPubContext.adapters.mqClient.publish as SinonStub).callCount).to.be.eq(0);


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [x] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## What's done

<!--- Describe your changes in more detail -->

- [x] Update the codebase of the pending domain transfers to make the pagination working.
- [x] Refactor a retry mechanism. The previous one tried to send xcalls in 2s, 4s, 8s, 16s, 256s... but it didn't make sense to re-send 8 times within 4mins. 4 mins is the average execution window so no need to resend within its period  

