### PR TITLE
fix: macro L-1 set dispute block event arguments

### DIFF
--- a/packages/deployments/contracts/contracts/messaging/RootManager.sol
+++ b/packages/deployments/contracts/contracts/messaging/RootManager.sol
@@ -318,7 +318,7 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
    */
   function setMinDisputeBlocks(uint256 _minDisputeBlocks) public onlyOwner {
     if (_minDisputeBlocks == minDisputeBlocks) revert RootManager_setMinDisputeBlocks__SameMinDisputeBlocksAsBefore();
-    emit MinDisputeBlocksUpdated(_minDisputeBlocks, minDisputeBlocks);
+    emit MinDisputeBlocksUpdated(minDisputeBlocks, _minDisputeBlocks);
     minDisputeBlocks = _minDisputeBlocks;
   }
 

--- a/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
@@ -700,7 +700,7 @@ contract RootManager_SetMinDisputeBlocks is Base {
     vm.prank(owner);
 
     vm.expectEmit(true, true, true, true);
-    emit MinDisputeBlocksUpdated(newMinDisputeBlocks, _prevMinDisputeBlocks);
+    emit MinDisputeBlocksUpdated(_prevMinDisputeBlocks, newMinDisputeBlocks);
 
     _rootManager.setMinDisputeBlocks(newMinDisputeBlocks);
   }


### PR DESCRIPTION
## Description

Fixes the order of arguments passed to `MinDisputeBlocksUpdated` event on `setMinDisputeBlocks` function.

## Type of change
- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

## Related Issue(s)

## Related pull request(s)

