### PR TITLE
Add ladao-xocolatl to prod allow-listing

### DIFF
--- a/packages/deployments/contracts/src/cli/init/config/mainnet/production.ts
+++ b/packages/deployments/contracts/src/cli/init/config/mainnet/production.ts
@@ -211,6 +211,26 @@ export const MAINNET_PRODUCTION_INIT_CONFIG: InitConfig = {
         },
       },
     },
+    {
+      name: "XOC",
+      // polygon
+      canonical: {
+        domain: "1886350457",
+        address: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+        decimals: 18,
+        cap: utils.parseUnits("25000", 18).toString(),
+      },
+      representations: {
+        // gnosis
+        "1869640809": {
+          adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+        },
+        // bsc
+        "6450786": {
+          adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+        },
+      },
+    },
   ],
   agents: {
     watchers: {

--- a/packages/deployments/contracts/src/cli/init/config/mainnet/production.ts
+++ b/packages/deployments/contracts/src/cli/init/config/mainnet/production.ts
@@ -221,12 +221,29 @@ export const MAINNET_PRODUCTION_INIT_CONFIG: InitConfig = {
         cap: utils.parseUnits("25000", 18).toString(),
       },
       representations: {
-        // gnosis
+        // mainnet
+        "6648936": {
+          local: "0x0000000000000000000000000000000000000000",
+          adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+        },
+        // optimism
         "1869640809": {
+          local: "0x0000000000000000000000000000000000000000",
+          adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+        },
+        // arbitrum one
+        "1634886255": {
+          local: "0x0000000000000000000000000000000000000000",
           adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
         },
         // bsc
         "6450786": {
+          local: "0x0000000000000000000000000000000000000000",
+          adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+        },
+        // gnosis
+        "6778479": {
+          local: "0x0000000000000000000000000000000000000000",
           adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
         },
       },

--- a/packages/deployments/contracts/src/cli/init/config/mainnet/production.ts
+++ b/packages/deployments/contracts/src/cli/init/config/mainnet/production.ts
@@ -224,26 +224,26 @@ export const MAINNET_PRODUCTION_INIT_CONFIG: InitConfig = {
         // mainnet
         "6648936": {
           local: "0x0000000000000000000000000000000000000000",
-          adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+          adopted: "0x0000000000000000000000000000000000000000",
         },
         // optimism
         "1869640809": {
           local: "0x0000000000000000000000000000000000000000",
-          adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+          adopted: "0x0000000000000000000000000000000000000000",
         },
         // arbitrum one
         "1634886255": {
           local: "0x0000000000000000000000000000000000000000",
-          adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+          adopted: "0x0000000000000000000000000000000000000000",
         },
         // bsc
         "6450786": {
-          local: "0x0000000000000000000000000000000000000000",
+          local: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
           adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
         },
         // gnosis
         "6778479": {
-          local: "0x0000000000000000000000000000000000000000",
+          local: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
           adopted: "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
         },
       },


### PR DESCRIPTION
## Description
Adding Xocolatl MXN Stablecoin $XOC, to the production allow-listed script.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

This pull request adds the representations by domain of Xocolatl MXN Stablecoin. 
Connext address currently has mint/burn auth in Polygon(POS), Gnosis, and BSC.
Representations were added to `MAINNET_PRODUCTION_INIT_CONFIG` object in the array of `assets` to file ~/packages/deployments/contracts/src/cli/init/config/mainnet/production.ts

## Related Issue(s)
N/A

## Related pull request(s)
[chaindata repo pull request 75](https://github.com/connext/chaindata/pull/75)

