### PR TITLE
fix: add safe guard to lh to not propose when subgraph stale

### DIFF
--- a/packages/agents/lighthouse/src/tasks/propose/errors.ts
+++ b/packages/agents/lighthouse/src/tasks/propose/errors.ts
@@ -131,3 +131,18 @@ export class AggregateRootChecksFailed extends NxtpError {
     });
   }
 }
+
+export class SubgraphDelayed extends NxtpError {
+  constructor(
+    public readonly hubDomain: string,
+    public readonly requestContext: RequestContext,
+    public readonly methodContext: MethodContext,
+    public readonly context: any = {},
+  ) {
+    super(`Subgraph is more than 1 snapshot behind the latest snapshot for domain ${hubDomain}`, {
+      ...context,
+      requestContext,
+      methodContext,
+    });
+  }
+}

--- a/packages/agents/lighthouse/src/tasks/propose/propose.ts
+++ b/packages/agents/lighthouse/src/tasks/propose/propose.ts
@@ -110,6 +110,9 @@ export const makePropose = async (config: NxtpLighthouseConfig, chainData: Map<s
     // Start the propose task.
     const rootManagerMode: RootManagerMode = await context.adapters.subgraph.getRootManagerMode(config.hubDomain);
     const domains: string[] = Object.keys(config.chains);
+    let proposeHubSuccess = true;
+    let proposeSpokeSuccess = true;
+
     for (const domain of domains) {
       const spokeConnectorMode: SpokeConnectorMode = await context.adapters.subgraph.getSpokeConnectorMode(domain);
       if (spokeConnectorMode.mode !== rootManagerMode.mode) {
@@ -126,9 +129,20 @@ export const makePropose = async (config: NxtpLighthouseConfig, chainData: Map<s
         );
       }
     }
+
     if (rootManagerMode.mode === ModeType.OptimisticMode) {
       context.logger.info("In Optimistic Mode", requestContext, methodContext);
-      await proposeHub();
+
+      try {
+        await proposeHub();
+      } catch (e: unknown) {
+        context.logger.error("Failed to propose to hub ", requestContext, methodContext, jsonifyError(e as NxtpError), {
+          hubDomain: config.hubDomain,
+        });
+
+        proposeHubSuccess = false;
+      }
+
       for (const spokeDomain of domains) {
         try {
           await proposeSpoke(spokeDomain);
@@ -140,6 +154,8 @@ export const makePropose = async (config: NxtpLighthouseConfig, chainData: Map<s
             jsonifyError(e as NxtpError),
             { spokeDomain },
           );
+
+          proposeSpokeSuccess = false;
         }
       }
     } else if (rootManagerMode.mode === ModeType.SlowMode) {
@@ -147,7 +163,8 @@ export const makePropose = async (config: NxtpLighthouseConfig, chainData: Map<s
     } else {
       throw new Error(`Unknown mode detected: ${JSON.stringify(rootManagerMode)}`);
     }
-    if (context.config.healthUrls.propose) {
+
+    if (context.config.healthUrls.propose && proposeHubSuccess && proposeSpokeSuccess) {
       await sendHeartbeat(context.config.healthUrls.propose, context.logger);
     }
   } catch (e: unknown) {


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
fix: add safe guard to lh to not propose when subgraph stale
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
