### PR TITLE
fix: increase lh prover frequncy to once an hour reduce opex

### DIFF
--- a/ops/mainnet/prod/core/main.tf
+++ b/ops/mainnet/prod/core/main.tf
@@ -303,7 +303,7 @@ module "lighthouse_prover_cron" {
   container_env_vars = merge(local.lighthouse_env_vars, {
     LIGHTHOUSE_SERVICE = "prover-pub"
   })
-  schedule_expression    = "rate(5 minutes)"
+  schedule_expression    = "rate(60 minutes)"
   timeout                = 300
   memory_size            = 10240
   lambda_in_vpc          = true


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
Increase lh prover frequency to once an hour, to reduce messaging opex.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [x] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
