### PR TITLE
5877 reset errors

### DIFF
--- a/packages/adapters/database/src/client.ts
+++ b/packages/adapters/database/src/client.ts
@@ -1550,7 +1550,11 @@ export const resetBackoffs = async (
   const poolToUse = _pool ?? pool;
   const backoff = 32;
   await db
-    .update("transfers", { backoff, next_execution_timestamp: 0 }, { transfer_id: dc.isIn(transferIds) })
+    .update(
+      "transfers",
+      { backoff, next_execution_timestamp: 0, error_status: null },
+      { transfer_id: dc.isIn(transferIds) },
+    )
     .run(poolToUse);
 };
 

--- a/packages/adapters/database/test/client.spec.ts
+++ b/packages/adapters/database/test/client.spec.ts
@@ -1257,10 +1257,12 @@ describe("Database client", () => {
     queryRes = await pool.query("SELECT * FROM transfers WHERE transfer_id = $1", [transfer1.transferId]);
     expect(queryRes.rows[0].backoff).to.eq(32);
     expect(queryRes.rows[0].next_execution_timestamp).to.eq(0);
+    expect(queryRes.rows[0].error_status).to.be.null;
 
     queryRes = await pool.query("SELECT * FROM transfers WHERE transfer_id = $1", [transfer2.transferId]);
     expect(queryRes.rows[0].backoff).to.eq(32);
     expect(queryRes.rows[0].next_execution_timestamp).to.eq(0);
+    expect(queryRes.rows[0].error_status).to.be.null;
 
     queryRes = await pool.query("SELECT * FROM transfers WHERE transfer_id = $1", [transfer3.transferId]);
     expect(queryRes.rows[0].backoff).to.eq(64);

--- a/packages/agents/cartographer/poller/src/lib/operations/transfers.ts
+++ b/packages/agents/cartographer/poller/src/lib/operations/transfers.ts
@@ -219,7 +219,7 @@ export const updateBackoffs = async (): Promise<void> => {
     logger,
     domains,
   } = getContext();
-  const { requestContext, methodContext } = createLoggingContext("updateTransfers");
+  const { requestContext, methodContext } = createLoggingContext("updateBackoffs");
   const subgraphRelayerFeeQueryMetaParams: Map<string, SubgraphQueryByTimestampMetaParams> = new Map();
   const subgraphSlippageUpdatesQueryMetaParams: Map<string, SubgraphQueryByTimestampMetaParams> = new Map();
   await Promise.all(


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

- Resets the `error_status` along with backoff and execution timeouts

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

TLDR:

- transfer error statuses are not always updated dynamically, they update according to an exponential backoff
- this could cause stale errors, particularly around relayer fees and slippage which are moment-in-time evaluation
- slippage / relayer fee changes reset the backoff, but not always the error which leaves the error handling to be offloaded onto the client, and is not indicative of the error on the latest transfer params
- there could be other issues around the errors being stale, which we will have to resolve manually, but resetting the errors on increase will help as well

Considered making a separate database function or flag, but `resetBackoffs` is only ever used in the case new slippage or relayer fee updates come in.

## Related Issue(s)

Fixes #5877 
Fixes #5892 

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
