### PR TITLE
fix: move max enforcement to utils

### DIFF
--- a/packages/agents/sdk/src/sdkBase.ts
+++ b/packages/agents/sdk/src/sdkBase.ts
@@ -653,25 +653,6 @@ export class SdkBase extends SdkShared {
       requestContext,
     );
 
-    if (this.chainData) {
-      const maxRelayerFeeInNative = this.chainData.get(params.destinationDomain.toString())?.maxRelayerFeeInNative;
-      const maxRelayerFeeInNativeBN = BigNumber.from(maxRelayerFeeInNative ?? relayerFee);
-      if (params.priceIn === "usd") {
-        const scaleFactor = 10000; // leave some precision for low value assets
-        const scaledOriginNativeTokenPrice = originNativeTokenPrice * scaleFactor;
-
-        // Truncate remaining decimals and convert back to USD
-        const originNativeTokenPriceUsdBN = BigNumber.from(
-          scaledOriginNativeTokenPrice.toString().split('.')[0]
-        ).div(scaleFactor);
-
-        const maxRelayerFeeInUsdBN = maxRelayerFeeInNativeBN.mul(originNativeTokenPriceUsdBN);
-        if (relayerFee.gt(maxRelayerFeeInUsdBN)) return maxRelayerFeeInUsdBN;
-      } else {
-        if (relayerFee.gt(maxRelayerFeeInNativeBN)) return maxRelayerFeeInNativeBN;
-      }
-    }
-
     return relayerFee;
   }
 

--- a/packages/agents/sdk/test/sdkBase.spec.ts
+++ b/packages/agents/sdk/test/sdkBase.spec.ts
@@ -598,7 +598,7 @@ describe("SdkBase", () => {
 
     beforeEach(() => {
       calculateRelayerFeeStub = stub(SharedFns, "calculateRelayerFee");
-      getConversionRateStub = stub(SharedFns, "getConversionRate")
+      getConversionRateStub = stub(SharedFns, "getConversionRate");
     });
 
     afterEach(() => {
@@ -614,36 +614,6 @@ describe("SdkBase", () => {
       });
       expect(calculateRelayerFeeStub.callCount).to.be.eq(1);
       expect(relayerFee.toString()).to.be.eq("100");
-    });
-
-    it("should return maxRelayerFeeInNative from chaindata if estimate is too high", async () => {
-      calculateRelayerFeeStub.resolves(BigNumber.from(100_000_000_000));
-      const relayerFee = await sdkBase.estimateRelayerFee({
-        originDomain: mock.domain.A,
-        destinationDomain: mock.domain.A,
-      });
-      expect(relayerFee.toString()).to.be.eq(sdkBase.chainData.get(mock.domain.A)!.maxRelayerFeeInNative);
-    });
-
-    it("should return converted fee from chaindata if estimate is too high and is in usd, ", async () => {
-      calculateRelayerFeeStub.resolves(BigNumber.from(100_000_000_000));
-      const relayerFee = await sdkBase.estimateRelayerFee({
-        originDomain: mock.domain.A,
-        destinationDomain: mock.domain.A,
-        priceIn: "usd",
-        originNativeTokenPrice: 100,
-        destinationNativeTokenPrice: 100,
-      });
-      expect(relayerFee.toString()).to.be.eq(BigNumber.from(100_000_000).toString());
-    });
-
-    it("should return high estimate if no override in chaindata", async () => {
-      calculateRelayerFeeStub.resolves(BigNumber.from(100_000_000_000));
-      const relayerFee = await sdkBase.estimateRelayerFee({
-        originDomain: mock.domain.A,
-        destinationDomain: mock.domain.B,
-      });
-      expect(relayerFee.toString()).to.be.eq(BigNumber.from(100_000_000_000).toString());
     });
   });
 

--- a/packages/utils/src/mocks/mock.ts
+++ b/packages/utils/src/mocks/mock.ts
@@ -94,7 +94,7 @@ export const mock = {
           analytics: [{ query: "http://example.com", health: "http://example.com" }],
           maxLag: 10,
         },
-        maxRelayerFeeInNative: "1000000"
+        maxRelayerFeeInEth: "1000000",
       },
       {
         name: "Unit Test Chain 2",
@@ -107,6 +107,7 @@ export const mock = {
           analytics: [{ query: "http://example.com", health: "http://example.com" }],
           maxLag: 10,
         },
+        maxRelayerFeeInEth: "1000000",
       },
     ]),
   signature: mkSig("0xabcdef1c"),

--- a/packages/utils/src/peripherals/chainData.ts
+++ b/packages/utils/src/peripherals/chainData.ts
@@ -72,7 +72,7 @@ export type ChainData = {
     messaging: string;
     gasPriceFactor?: string;
   };
-  maxRelayerFeeInNative: string;
+  maxRelayerFeeInEth: string;
 };
 
 // Helper method to reorganize this list into a mapping by chain ID for quicker lookup.

--- a/packages/utils/test/peripherals/relayer.spec.ts
+++ b/packages/utils/test/peripherals/relayer.spec.ts
@@ -46,6 +46,36 @@ describe("Peripherals:Relayer", () => {
       expect(estimatedRelayerFee).to.be.deep.eq(BigNumber.from("18000"));
     });
 
+    it("should return correct capped value", async () => {
+      getConversionRateStub.onFirstCall().resolves(1);
+      getConversionRateStub.onSecondCall().resolves(150);
+      getConversionRateStub.onThirdCall().resolves(1);
+      getGelatoEstimatedFeeStub.resolves(BigNumber.from(10000));
+      const estimatedRelayerFee = await calculateRelayerFee(
+        { originDomain: "13337", destinationDomain: "13338" },
+        mock.chainData(),
+        logger,
+      );
+      // estimatedRelayerFee = (estimatedGelatoFee + estimatedGelatoFee x buffer_percentage / 100) x ( destinationTokenPrice / originTokenPrice )
+      // ==> (10000 + 10000 x 20 / 100) x ( 150 / 1 ) = 1800000 > 1000000
+      expect(estimatedRelayerFee).to.be.deep.eq(BigNumber.from("1000000"));
+    });
+
+    it("should return correct capped value in native", async () => {
+      getConversionRateStub.onFirstCall().resolves(1);
+      getConversionRateStub.onSecondCall().resolves(150);
+      getConversionRateStub.onThirdCall().resolves(1);
+      getGelatoEstimatedFeeStub.resolves(BigNumber.from(10000));
+      const estimatedRelayerFee = await calculateRelayerFee(
+        { originDomain: "13337", destinationDomain: "13338", priceIn: "native" },
+        mock.chainData(),
+        logger,
+      );
+      // estimatedRelayerFee = (estimatedGelatoFee + estimatedGelatoFee x buffer_percentage / 100) x ( destinationTokenPrice / originTokenPrice )
+      // ==> (10000 + 10000 x 20 / 100) x ( 150 / 1 ) = 1800000 > 1000000
+      expect(estimatedRelayerFee).to.be.deep.eq(BigNumber.from("1000000"));
+    });
+
     it("should return correct value when provided token prices", async () => {
       getGelatoEstimatedFeeStub.resolves(BigNumber.from(10000));
       const estimatedRelayerFee = await calculateRelayerFee(


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

Closes #5996 

- Moves max enforcement logic to shared utilities, not just `sdkBase`
- Updates the utils to ensure the prices are denominated in WETH

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
